### PR TITLE
Error during cut initialisation

### DIFF
--- a/docs/releases/changelog-v3.0.md
+++ b/docs/releases/changelog-v3.0.md
@@ -1,4 +1,4 @@
-# Release 3.0.0-dev (development release)
+# Release 3.0
 
 ## New features since last release
   * Complete interface with PAD in order to run exclusion limits externally
@@ -17,6 +17,9 @@
 ## Bug fixes
  * Make exceptions accessible through `ma5.system` module
     ([#7](https://github.com/MadAnalysis/ma5_expert/pull/7)).
+
+ * Signal region initialisation fixes in cutflow collection.
+   ([#9](https://github.com/MadAnalysis/ma5_expert/pull/9))
 
 ## Contributors
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if os.path.isfile("./requirements.txt"):
 
 setup(
     name="ma5_expert",
-    version="3.0.2",
+    version="3.0.3",
     description=("MadAnalysis 5 interpreter for Expert mode"),
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -20,7 +20,7 @@ setup(
     project_urls={
         "Bug Tracker": "https://github.com/MadAnalysis/ma5_expert/issues",
     },
-    download_url="https://github.com/MadAnalysis/ma5_expert/archive/refs/tags/v3.0.2.tar.gz",
+    download_url="https://github.com/MadAnalysis/ma5_expert/archive/refs/tags/v3.0.3.tar.gz",
     author="Jack Y. Araz",
     author_email=("jack.araz@durham.ac.uk"),
     license="MIT",

--- a/src/ma5_expert/cutflow/reader.py
+++ b/src/ma5_expert/cutflow/reader.py
@@ -116,7 +116,7 @@ class Collection:
                 self._srID.append(currentSR.id)
             except Exception as err:
                 log.error(err)
-                currentSR.id = f"SR_{len(self.srID)}"
+                currentSR.id = f"SR_{len(self._srID)}"
                 setattr(self, currentSR.id, currentSR)
                 self._srID.append(currentSR.id)
 
@@ -156,15 +156,15 @@ class Collection:
             if ix == 0:
                 current_cut = Cut(
                     name=name,
-                    Nevents=val,
+                    _Nevents = val,
                     Nentries=entries,
                 )
             else:
                 current_cut = Cut(
                     name=name,
-                    previous_cut=SR[-1],
-                    initial_cut=SR[0],
-                    Nevents=val,
+                    _previous_cut=SR[-1],
+                    _initial_cut=SR[0],
+                    _Nevents=val,
                     Nentries=entries,
                 )
             SR.addCut(current_cut)
@@ -174,7 +174,7 @@ class Collection:
             self._srID.append(SR.id)
         except Exception as err:
             log.error(err)
-            SR.id = f"SR_{len(self.srID)}"
+            SR.id = f"SR_{len(self._srID)}"
             setattr(self, SR.id, SR)
             self._srID.append(SR.id)
 


### PR DESCRIPTION
This PR resolves issues in cut flow collection where `addSignalRegion` had wrong input names for the `Cut` object.